### PR TITLE
Add Makefile with restore target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: help restore
+
+# Simple helper for setting up the development environment
+help:
+	@echo "Usage: make restore"
+	@echo "  restore - Create .venv with uv and install dependencies"
+
+restore:
+	@test -d .venv || uv venv .venv
+	@.venv/bin/uv pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- provide a simple Makefile
- add a `restore` target that creates `.venv` with `uv` and installs `requirements.txt`
- document usage via a `help` target

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e694c9c08832098f2a010c7ddb20f